### PR TITLE
removed dangerouslySetInnerHTML in place of src

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,6 +1,6 @@
-'use strict';
+"use strict";
 
-var _react = require('react');
+var _react = require("react");
 
 var _react2 = _interopRequireDefault(_react);
 
@@ -9,5 +9,8 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 exports.onRenderBody = function (_ref, pluginOptions) {
   var setPostBodyComponents = _ref.setPostBodyComponents;
 
-  return setPostBodyComponents([_react2.default.createElement('script', { key: 'gatsby-plugin-stripe-checkout', dangerouslySetInnerHTML: { __html: 'src="https://checkout.stripe.com/checkout.js"' } })]);
+  return setPostBodyComponents([_react2.default.createElement("script", {
+    key: "gatsby-plugin-stripe-checkout",
+    src: "https://checkout.stripe.com/checkout.js"
+  })]);
 };

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -1,7 +1,10 @@
-import React from 'react';
+import React from "react";
 
 exports.onRenderBody = ({ setPostBodyComponents }, pluginOptions) => {
   return setPostBodyComponents([
-    <script key='gatsby-plugin-stripe-checkout' dangerouslySetInnerHTML={{ __html: 'src="https://checkout.stripe.com/checkout.js"' }} />
+    <script
+      key="gatsby-plugin-stripe-checkout"
+      src="https://checkout.stripe.com/checkout.js"
+    />
   ]);
-}
+};


### PR DESCRIPTION
I found that when trying to implement this plugin into my project the script tags were rendered like this at the end of the `<body>`:

```
<script>src="https://checkout.stripe.com/checkout.js"</script>
```

Changing the dangerouslySetInnerHTML and just leaving it as a src tag seemed to do the trick, though maybe I'm missing some edge case where dangerouslySetInnerHTML is needed? 

I ran into this when I cloned the unicorn-mart project (which runs fine) because it had the custom implementation of the plugin that uses a simple key and src vs. key and dangerouslySetInnerHTML. Trying to implement it myself StripeCheckout was undefined even though I could see the script tag in the page source. Took me a few minutes debugging to realize the src was outside of the tag.