### PR TITLE
Simplify code

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,12 @@ To load the `<script>` tag asyncronously, pass an 'async' option in `gatsby-conf
 ```javascript
 module.exports = {
   plugins: [
-    `gatsby-plugin-stripe-checkout`,
-    options: {
-      async: true
-    }
-  ]
+    {
+      resolve: `gatsby-plugin-stripe-checkout`,
+      options: {
+        async: true,
+      },
+    },
+  ],
 }
 ```

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -9,11 +9,9 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 exports.onRenderBody = function (_ref, options) {
   var setPostBodyComponents = _ref.setPostBodyComponents;
 
-  var script = null;
-  if (options.async) {
-    script = _react2.default.createElement("script", { key: "gatsby-plugin-stripe-checkout", src: "https://checkout.stripe.com/checkout.js", async: true });
-  } else {
-    script = _react2.default.createElement("script", { key: "gatsby-plugin-stripe-checkout", src: "https://checkout.stripe.com/checkout.js" });
-  }
-  return setPostBodyComponents([script]);
+  return setPostBodyComponents([_react2.default.createElement("script", {
+    key: "gatsby-plugin-stripe-checkout",
+    src: "https://checkout.stripe.com/checkout.js",
+    async: options.async
+  })]);
 };

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -1,11 +1,12 @@
 import React from 'react';
 
 exports.onRenderBody = ({ setPostBodyComponents }, options) => {
-  let script = null;
-  if (options.async) {
-    script = <script key="gatsby-plugin-stripe-checkout" src="https://checkout.stripe.com/checkout.js" async />;
-  } else {
-    script = <script key="gatsby-plugin-stripe-checkout" src="https://checkout.stripe.com/checkout.js" />;
-  }
-  return setPostBodyComponents([script]);
+  return setPostBodyComponents([
+    <script
+      key="gatsby-plugin-stripe-checkout"
+      src="https://checkout.stripe.com/checkout.js"
+      async={options.async}
+    />
+  ]);
+
 };


### PR DESCRIPTION
This PR simplifies the code for the `async` attribute in the `<script>` tag. Now there isn't any unnecessary code duplication, which reduces the surface area for future bugs (eg. if you change one of the `script = ...` lines and forget to change the other).

The example in the README didn't work, so I fixed that as well.